### PR TITLE
"/" menu render + editor changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/material": "^5.3.0",
         "axios": "^0.25.0",
         "dotenv": "^16.0.0",
+        "rc-menu": "^9.3.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-jwt": "^1.1.4",
@@ -5307,6 +5308,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
+    "node_modules/classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
     "node_modules/clean-css": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.4.tgz",
@@ -6308,6 +6314,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-align": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.2.tgz",
+      "integrity": "sha512-pHuazgqrsTFrGU2WLDdXxCFabkdQDx72ddkraZNih1KsMcN5qsRSTR9O4VJRlwTPCPb5COYg3LOfiMHHcPInHg=="
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -8451,11 +8462,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
-    },
-    "node_modules/immutable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
-      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -13215,6 +13221,123 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rc-align": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.11.tgz",
+      "integrity": "sha512-n9mQfIYQbbNTbefyQnRHZPWuTEwG1rY4a9yKlIWHSTbgwI+XUMGRYd0uJ5pE2UbrNX0WvnMBA1zJ3Lrecpra/A==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "dom-align": "^1.7.0",
+        "lodash": "^4.17.21",
+        "rc-util": "^5.3.0",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-menu": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.3.2.tgz",
+      "integrity": "sha512-h3m45oY1INZyqphGELkdT0uiPnFzxkML8m0VMhJnk2fowtqfiT7F5tJLT3znEVaPIY80vMy1bClCkgq8U91CzQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "rc-motion": "^2.4.3",
+        "rc-overflow": "^1.2.0",
+        "rc-trigger": "^5.1.2",
+        "rc-util": "^5.12.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-motion": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.4.6.tgz",
+      "integrity": "sha512-nXIHve2EDQZ8BFHfgJI3HYMMOZ7HGsolCfA9ozP99/gc1UqpgKys1TYrQWdXa2trff0V3JLhgn2zz+w9VsyktA==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.19.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-overflow": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.2.4.tgz",
+      "integrity": "sha512-nIeelyYfdS+mQBK1++FisLZEvZ8xVAzC+duG+TC4TmqNN+kTHraiGntV9/zxDGA1ruyQ91YRJ549JjFodCBnsw==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.19.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-resize-observer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.2.0.tgz",
+      "integrity": "sha512-6W+UzT3PyDM0wVCEHfoW3qTHPTvbdSgiA43buiy8PzmeMnfgnDeb9NjdimMXMl3/TcrvvWl5RRVdp+NqcR47pQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.15.0",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-trigger": {
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.2.11.tgz",
+      "integrity": "sha512-YS+BA4P2aqp9qU7dcTQwsK56SOLJk7XDaFynnXg96obJOUVFiQ6Lfomq9em2dlB4uSjd7Z/gjriZdUY8S2CPQw==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "classnames": "^2.2.6",
+        "rc-align": "^4.0.0",
+        "rc-motion": "^2.0.0",
+        "rc-util": "^5.19.2"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util": {
+      "version": "5.19.3",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.19.3.tgz",
+      "integrity": "sha512-S28epi9E2s7Nir05q8Ffl3hzDLwkavTGi0PGH1cTqCmkpG1AeBEuZgQDpksYeU6IgHcds5hWIPE5PUcdFiZl8w==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "react-is": "^16.12.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -13708,6 +13831,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -13996,6 +14124,11 @@
         }
       }
     },
+    "node_modules/sass/node_modules/immutable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
+    },
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -14197,6 +14330,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -20069,6 +20207,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
     "clean-css": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.4.tgz",
@@ -20795,6 +20938,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-align": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.2.tgz",
+      "integrity": "sha512-pHuazgqrsTFrGU2WLDdXxCFabkdQDx72ddkraZNih1KsMcN5qsRSTR9O4VJRlwTPCPb5COYg3LOfiMHHcPInHg=="
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -22351,11 +22499,6 @@
       "version": "9.0.12",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
       "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA=="
-    },
-    "immutable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
-      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -25657,6 +25800,94 @@
         }
       }
     },
+    "rc-align": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.11.tgz",
+      "integrity": "sha512-n9mQfIYQbbNTbefyQnRHZPWuTEwG1rY4a9yKlIWHSTbgwI+XUMGRYd0uJ5pE2UbrNX0WvnMBA1zJ3Lrecpra/A==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "dom-align": "^1.7.0",
+        "lodash": "^4.17.21",
+        "rc-util": "^5.3.0",
+        "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "rc-menu": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.3.2.tgz",
+      "integrity": "sha512-h3m45oY1INZyqphGELkdT0uiPnFzxkML8m0VMhJnk2fowtqfiT7F5tJLT3znEVaPIY80vMy1bClCkgq8U91CzQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "rc-motion": "^2.4.3",
+        "rc-overflow": "^1.2.0",
+        "rc-trigger": "^5.1.2",
+        "rc-util": "^5.12.0",
+        "shallowequal": "^1.1.0"
+      }
+    },
+    "rc-motion": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.4.6.tgz",
+      "integrity": "sha512-nXIHve2EDQZ8BFHfgJI3HYMMOZ7HGsolCfA9ozP99/gc1UqpgKys1TYrQWdXa2trff0V3JLhgn2zz+w9VsyktA==",
+      "requires": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.19.2"
+      }
+    },
+    "rc-overflow": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.2.4.tgz",
+      "integrity": "sha512-nIeelyYfdS+mQBK1++FisLZEvZ8xVAzC+duG+TC4TmqNN+kTHraiGntV9/zxDGA1ruyQ91YRJ549JjFodCBnsw==",
+      "requires": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.19.2"
+      }
+    },
+    "rc-resize-observer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.2.0.tgz",
+      "integrity": "sha512-6W+UzT3PyDM0wVCEHfoW3qTHPTvbdSgiA43buiy8PzmeMnfgnDeb9NjdimMXMl3/TcrvvWl5RRVdp+NqcR47pQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.15.0",
+        "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "rc-trigger": {
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.2.11.tgz",
+      "integrity": "sha512-YS+BA4P2aqp9qU7dcTQwsK56SOLJk7XDaFynnXg96obJOUVFiQ6Lfomq9em2dlB4uSjd7Z/gjriZdUY8S2CPQw==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "classnames": "^2.2.6",
+        "rc-align": "^4.0.0",
+        "rc-motion": "^2.0.0",
+        "rc-util": "^5.19.2"
+      }
+    },
+    "rc-util": {
+      "version": "5.19.3",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.19.3.tgz",
+      "integrity": "sha512-S28epi9E2s7Nir05q8Ffl3hzDLwkavTGi0PGH1cTqCmkpG1AeBEuZgQDpksYeU6IgHcds5hWIPE5PUcdFiZl8w==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "react-is": "^16.12.0",
+        "shallowequal": "^1.1.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -26032,6 +26263,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -26194,6 +26430,13 @@
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
         "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "dependencies": {
+        "immutable": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+          "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
+        }
       }
     },
     "sass-loader": {
@@ -26381,6 +26624,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@mui/material": "^5.3.0",
     "axios": "^0.25.0",
     "dotenv": "^16.0.0",
+    "rc-menu": "^9.3.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-jwt": "^1.1.4",

--- a/src/Components/SlateEditor/SlateEditor.js
+++ b/src/Components/SlateEditor/SlateEditor.js
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, {
+  createRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import "Components/SlateEditor/SlateEditor.scss";
 import {
   createEditor,
@@ -6,7 +12,9 @@ import {
   Transforms,
   Element as SlateElement,
 } from "slate";
-import { Slate, Editable, withReact } from "slate-react";
+import { Slate, Editable, withReact, ReactEditor } from "slate-react";
+import Menu, { Item as MenuItem } from "rc-menu";
+import "rc-menu/assets/index.css";
 
 export default function SlateEditor() {
   const editor = useMemo(() => withReact(createEditor()), []);
@@ -19,6 +27,40 @@ export default function SlateEditor() {
     ]
   );
   const LIST_TYPES = ["numbered-list", "bulleted-list"];
+  const [showMenu, setShowMenu] = useState(false);
+  const [coordinates, setCoordinates] = useState("");
+  const allowedTags = [
+    {
+      label: "h1",
+      value: "heading-one",
+    },
+    {
+      label: "h2",
+      value: "heading-two",
+    },
+    {
+      label: "quote",
+      value: "block-quote",
+    },
+    {
+      label: "numbered",
+      value: "numbered-list",
+    },
+    {
+      label: "bullets",
+      value: "bulleted-list",
+    },
+    {
+      label: "p",
+      value: "paragraph",
+    },
+  ];
+  const [menuOptions, setMenuOptions] = useState(allowedTags);
+  const menuFocus = createRef();
+
+  useEffect(() => {
+    menuFocus.current?.focus();
+  }, [menuFocus]);
 
   const renderElement = useCallback((props) => {
     switch (props.element.type) {
@@ -124,6 +166,70 @@ export default function SlateEditor() {
     },
   };
 
+  const getCoordinates = () => {
+    let x, y;
+    const selection = window.getSelection();
+    if (selection.rangeCount !== 0) {
+      const range = selection.getRangeAt(0).cloneRange();
+      range.collapse(false);
+      const rect = range.getClientRects()[0];
+      if (rect) {
+        x = rect.top;
+        y = rect.left;
+      }
+    }
+    return { top: x > 120 ? x - 150 : x + 20, left: y };
+  };
+
+  const closeMenu = useCallback(() => {
+    setShowMenu(false);
+    document.removeEventListener("click", closeMenu);
+  }, []);
+
+  const openMenu = useCallback(() => {
+    const position = getCoordinates();
+    setCoordinates(position);
+    setShowMenu(true);
+    document.addEventListener("click", closeMenu);
+  }, [closeMenu]);
+
+  const renderMenu = () => {
+    return (
+      <Menu
+        className="editor__menu"
+        style={coordinates}
+        ref={menuFocus}
+        onKeyDown={(event) => {
+          if (event.key === " " || event.key === "Backspace") {
+            closeMenu();
+            ReactEditor.focus(editor);
+            event.preventDefault();
+          }
+
+          if (event.key === "Enter") {
+            event.preventDefault();
+          }
+        }}
+      >
+        {menuOptions.map((item, key) => {
+          return (
+            <MenuItem
+              tabIndex="0"
+              key={key}
+              onClick={() => {
+                CustomEditor.toggleBlock(editor, item.value);
+                closeMenu();
+                ReactEditor.focus(editor);
+              }}
+            >
+              {item.label}
+            </MenuItem>
+          );
+        })}
+      </Menu>
+    );
+  };
+
   return (
     <div className="editor">
       <Slate
@@ -140,11 +246,32 @@ export default function SlateEditor() {
           }
         }}
       >
+        {showMenu ? renderMenu() : null}
         <Editable
+          id="editor__editable"
           className="editor__area"
           renderElement={renderElement}
           renderLeaf={renderLeaf}
           onKeyDown={(event) => {
+            if (event.key === "/") {
+              openMenu();
+            }
+            if (event.key === " " || event.key === "Backspace") {
+              closeMenu();
+            }
+            if (event.key === "Enter") {
+              event.preventDefault();
+              const isList = LIST_TYPES.includes(editor.getFragment()[0].type);
+              return isList
+                ? Transforms.insertNodes(editor, {
+                    type: "list-item",
+                    children: [{ text: "" }],
+                  })
+                : Transforms.insertNodes(editor, {
+                    type: "paragraph",
+                    children: [{ text: "" }],
+                  });
+            }
             if (!event.ctrlKey) {
               return;
             }

--- a/src/Components/SlateEditor/SlateEditor.js
+++ b/src/Components/SlateEditor/SlateEditor.js
@@ -70,60 +70,91 @@ export default function SlateEditor() {
     menuFocus.current?.focus();
   }, [menuFocus]);
 
+  const headingOneElement = (props) => (
+    <h1 {...props.attributes}>{props.children}</h1>
+  );
+
+  const headingTwoElement = (props) => (
+    <h2 {...props.attributes}>{props.children}</h2>
+  );
+
+  const headingThreeElement = (props) => (
+    <h3 {...props.attributes}>{props.children}</h3>
+  );
+
+  const numberedListElement = (props) => (
+    <ol {...props.attributes} className="editor__styles--lists">
+      {props.children}
+    </ol>
+  );
+
+  const bulletedListElement = (props) => (
+    <ul {...props.attributes}>{props.children}</ul>
+  );
+
+  const listItemElement = (props) => (
+    <li {...props.attributes} className="editor__styles--lists">
+      {props.children}
+    </li>
+  );
+
+  const onChangeChecklist = useCallback(
+    (e, props) => {
+      const newProperties = {
+        type: "check-list",
+        children: props.children,
+        checked: e.target.checked,
+      };
+      Transforms.setNodes(editor, newProperties);
+    },
+    [editor]
+  );
+
+  const checkListElement = (props) => (
+    <span className="editor__styles--checklist">
+      <input
+        {...props.attributes}
+        type="checkbox"
+        className="editor__styles--checklist-input"
+        checked={props.children[0].props.parent.checked}
+        onChange={(e) => {
+          onChangeChecklist(e, props);
+        }}
+      />
+      {props.children}
+    </span>
+  );
+
+  const blockQuoteElement = (props) => (
+    <blockquote {...props.attributes} className="editor__styles--quote">
+      {props.children}
+    </blockquote>
+  );
+
   const renderElement = useCallback(
     (props) => {
       switch (props.element.type) {
-        case "block-quote":
-          return (
-            <blockquote {...props.attributes} className="editor__styles--quote">
-              {props.children}
-            </blockquote>
-          );
-        case "bulleted-list":
-          return <ul {...props.attributes}>{props.children}</ul>;
         case "heading-one":
-          return <h1 {...props.attributes}>{props.children}</h1>;
+          return headingOneElement(props);
         case "heading-two":
-          return <h2 {...props.attributes}>{props.children}</h2>;
+          return headingTwoElement(props);
         case "heading-three":
-          return <h3 {...props.attributes}>{props.children}</h3>;
-        case "list-item":
-          return (
-            <li {...props.attributes} className="editor__styles--lists">
-              {props.children}
-            </li>
-          );
+          return headingThreeElement(props);
         case "numbered-list":
-          return (
-            <ol {...props.attributes} className="editor__styles--lists">
-              {props.children}
-            </ol>
-          );
+          return numberedListElement(props);
+        case "bulleted-list":
+          return bulletedListElement(props);
         case "check-list":
-          return (
-            <span className="editor__styles--checklist">
-              <input
-                {...props.attributes}
-                type="checkbox"
-                className="editor__styles--checklist-input"
-                checked={props.children[0].props.parent.checked}
-                onChange={(e) => {
-                  const newProperties = {
-                    type: "check-list",
-                    children: props.children,
-                    checked: e.target.checked,
-                  };
-                  Transforms.setNodes(editor, newProperties);
-                }}
-              />
-              {props.children}
-            </span>
-          );
+          return checkListElement(props);
+        case "list-item":
+          return listItemElement(props);
+        case "block-quote":
+          return blockQuoteElement(props);
         default:
           return <p {...props.attributes}>{props.children}</p>;
       }
     },
-    [editor]
+    [editor, checkListElement]
   );
 
   const renderLeaf = useCallback((props) => <Leaf {...props} />, []);

--- a/src/Components/SlateEditor/SlateEditor.js
+++ b/src/Components/SlateEditor/SlateEditor.js
@@ -207,14 +207,6 @@ export default function SlateEditor() {
     setShowMenu(true);
   }, [setCoordinates, setShowMenu]);
 
-  const addMenuEventListener = useCallback(() => {
-    document.addEventListener("click", closeMenu);
-  }, [closeMenu]);
-
-  const removeMenuEventListener = useCallback(() => {
-    document.removeEventListener("click", closeMenu);
-  }, [closeMenu]);
-
   const menuOnKeyDown = useCallback(
     (event) => {
       if (
@@ -223,7 +215,6 @@ export default function SlateEditor() {
         event.key === "Escape"
       ) {
         closeMenu();
-        removeMenuEventListener();
         ReactEditor.focus(editor);
         event.preventDefault();
       }
@@ -232,17 +223,16 @@ export default function SlateEditor() {
         event.preventDefault();
       }
     },
-    [closeMenu, editor, removeMenuEventListener]
+    [closeMenu, editor]
   );
 
   var onClickMenu = useCallback(
     (item) => {
       CustomEditor.toggleBlock(editor, item.value);
       closeMenu();
-      removeMenuEventListener();
       ReactEditor.focus(editor);
     },
-    [closeMenu, editor, removeMenuEventListener]
+    [closeMenu, editor]
   );
 
   const markdownListMenuOptions = menuOptions.map((item, key) => {
@@ -253,7 +243,7 @@ export default function SlateEditor() {
     );
   });
 
-  const markdownListMenu = useCallback(() => {
+  const MarkdownListMenu = useCallback(() => {
     return (
       <Menu
         className="editor__menu"
@@ -267,14 +257,19 @@ export default function SlateEditor() {
   }, [markdownListMenuOptions, coordinates, menuFocus, menuOnKeyDown]);
 
   const RenderMarkdownListMenu = useCallback(() => {
-    return showMenu ? showMenu && markdownListMenu() : null;
-  }, [showMenu, markdownListMenu]);
+    return showMenu ? showMenu && <MarkdownListMenu /> : null;
+  }, [showMenu]);
+
+  useEffect(() => {
+    showMenu
+      ? document.addEventListener("click", closeMenu)
+      : document.removeEventListener("click", closeMenu);
+  }, [showMenu, closeMenu]);
 
   const editorOnKeyDown = useCallback(
     (event) => {
       if (event.key === "/") {
         openMenu();
-        addMenuEventListener();
       }
 
       if (event.key === "Enter") {
@@ -331,7 +326,7 @@ export default function SlateEditor() {
         }
       }
     },
-    [addMenuEventListener, editor, openMenu]
+    [editor, openMenu]
   );
 
   return (

--- a/src/Components/SlateEditor/SlateEditor.js
+++ b/src/Components/SlateEditor/SlateEditor.js
@@ -248,7 +248,6 @@ export default function SlateEditor() {
       >
         {showMenu ? renderMenu() : null}
         <Editable
-          id="editor__editable"
           className="editor__area"
           renderElement={renderElement}
           renderLeaf={renderLeaf}

--- a/src/Components/SlateEditor/SlateEditor.scss
+++ b/src/Components/SlateEditor/SlateEditor.scss
@@ -12,6 +12,11 @@
     line-height: 1;
   }
 
+  input[type="checkbox"]:checked + span {
+    color: grey;
+    text-decoration: line-through;
+  }
+
   &__styles {
     &--quote {
       border-left: 2px solid grey;
@@ -22,6 +27,17 @@
 
     &--lists {
       margin: 8px 2px;
+    }
+
+    &--checklist {
+      display: flex;
+      align-items: center;
+      margin: 8px 5px;
+
+      &-input {
+        margin-right: 1rem;
+        cursor: pointer;
+      }
     }
 
     &--code {

--- a/src/Components/SlateEditor/SlateEditor.scss
+++ b/src/Components/SlateEditor/SlateEditor.scss
@@ -34,17 +34,9 @@
     background-color: #191919;
     z-index: 999;
     position: absolute;
-    width: 10rem;
+    width: 12rem;
     height: 10rem;
     overflow-y: scroll;
     cursor: pointer;
-
-    //   &--item {
-    //     padding: 5px 0;
-
-    //     &:focus {
-    //       background-color: lightblue;
-    //     }
-    //   }
   }
 }

--- a/src/Components/SlateEditor/SlateEditor.scss
+++ b/src/Components/SlateEditor/SlateEditor.scss
@@ -28,4 +28,23 @@
       font-size: 1.4rem;
     }
   }
+
+  &__menu {
+    opacity: 1;
+    background-color: #191919;
+    z-index: 999;
+    position: absolute;
+    width: 10rem;
+    height: 10rem;
+    overflow-y: scroll;
+    cursor: pointer;
+
+    //   &--item {
+    //     padding: 5px 0;
+
+    //     &:focus {
+    //       background-color: lightblue;
+    //     }
+    //   }
+  }
 }

--- a/src/Components/SlateEditor/SlateEditor.scss
+++ b/src/Components/SlateEditor/SlateEditor.scss
@@ -20,6 +20,10 @@
       margin-left: 0;
     }
 
+    &--lists {
+      margin: 8px 2px;
+    }
+
     &--code {
       background-color: #87837826;
       color: #eb5757;


### PR DESCRIPTION
**In this PR:**
- have added a menu with different options to shift the current block to different text styles like h1, h2, quote, etc
- render the menu using the "/" key from the user and surrounding
- focusing on the menu when "/" is clicked and getting the focus back to the editor when an option is selected
- workaround the changing of every next block to a basic "p" tag automatically which before used to shift to the parent block
- not shifting next line to "p" tag when a list (numbered-list, bulleted-list) is being used

attaching a loom demo of the whole part below:
https://www.loom.com/share/9a8b7e152d344c8b88720f0a2f05f3bf